### PR TITLE
feat: Add deletedAt column to Collection table for soft delete functionality

### DIFF
--- a/prisma/migrations/20241230070749_add_deleted_at_to_collection_for_soft_deletion/migration.sql
+++ b/prisma/migrations/20241230070749_add_deleted_at_to_collection_for_soft_deletion/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Collection" ADD COLUMN     "deletedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Collection {
     updatedAt     DateTime @updatedAt
     user          User     @relation(fields: [userId], references: [id], onDelete: Cascade)
     userId        String
+    deletedAt       DateTime?
 }
 
 // Necessary for Next auth


### PR DESCRIPTION
## Description

This pull request adds a `deletedAt` column to the `Collection` table in the database schema to support soft delete functionality. The column is a nullable `DateTime` field, with a default value of `NULL`. When populated, it indicates that a collection has been soft-deleted.

## Changes Made

- Prisma Schema Update:  
  Added the `deletedAt` field to the `Collection` model in `prisma/schema.prisma`.  
- Database Migration:  
  Generated and applied a migration to modify the database schema by adding the `deletedAt` column.

## Impact

- Provides the foundation for soft delete functionality, recovery mechanisms, and scheduled cleanup of soft-deleted collections.
- Ensures backward compatibility by defaulting `deletedAt` to `NULL`, so existing functionality remains unaffected.

## Files Changed

- `prisma/schema.prisma`: Updated schema to include the `deletedAt` field.
- `prisma/migrations/20241230070749_add_deleted_at_to_collection_for_soft_deletion/migration.sql`: Migration script to add the `deletedAt` column to the database.

## Testing

- Manual Verification:  
  Inspected the database schema to confirm the addition of the `deletedAt` column.  
  Verified CRUD operations on the `Collection` table function correctly with the new column.  
- Migration Tested:  
  Successfully applied the migration without errors.

---

This change sets up the next steps for implementing soft delete, recovery, and cleanup logic.
