### PR TITLE
Fix: Card order changes when updating count

### DIFF
--- a/src/server/api/routers/collection.ts
+++ b/src/server/api/routers/collection.ts
@@ -73,8 +73,13 @@ export const collectionRouter = createTRPCRouter({
             include: {
               card: true,
             },
+            orderBy: {
+              card: {
+                id: 'asc'
+              }
+            }
           },
-        }
+        },
       });
     }),
 


### PR DESCRIPTION
Fixed it by using `orderBy` on `collection.byId` query.

I imagine we'll be able to sort by other things later. Pretty cool.